### PR TITLE
update to 4.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,8 +56,18 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
+    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c2deacbdb2a42825e198b35f46af13625c820e00e000f2fde2187cdb12c870b9
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.5.0" %}
+{% set version = "4.6.0" %}
 
 package:
   name: traits
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: traits-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/t/traits/traits-{{ version }}.tar.gz
-  md5: 3ad558eebaedc63c29c80183c0371d2f
+  url: https://github.com/enthought/traits/archive/{{ version }}.tar.gz
+  sha256: c2deacbdb2a42825e198b35f46af13625c820e00e000f2fde2187cdb12c870b9
 
 build:
   number: 0


### PR DESCRIPTION
the same pypi redirect wasn't working for 4.6.0, so switched to a github link here